### PR TITLE
rebind the...

### DIFF
--- a/camel-sap/site/pom.xml
+++ b/camel-sap/site/pom.xml
@@ -42,6 +42,22 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+						<configuration>
+							<attach>false</attach>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>ianal-maven-plugin</artifactId>
 				<configuration>


### PR DESCRIPTION
rebind the maven-source-plugin:attach-sources step to the correct generate-sources phase so that it doesn't delete the target folder AFTER generating the update site zip

Change-Id: Ib210985c4a757bb69ee2684807897e170e21e42e
Signed-off-by: nickboldt <nboldt@redhat.com>