### PR TITLE
rebind the...

### DIFF
--- a/camel-sap/pom.xml
+++ b/camel-sap/pom.xml
@@ -486,6 +486,7 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
+						<phase>generate-sources</phase>
 						<goals>
 							<goal>aggregate</goal>
 						</goals>


### PR DESCRIPTION
rebind the maven-source-plugin:attach-sources step to the correct generate-sources phase globally

Change-Id: Id7d60d3a69039228883602446d18789151d061ae
Signed-off-by: nickboldt <nboldt@redhat.com>